### PR TITLE
Linux: Fixed location of strcmp

### DIFF
--- a/Extractor/IsoHandler.cpp
+++ b/Extractor/IsoHandler.cpp
@@ -2,6 +2,7 @@
 #include "Constants.h"
 #include "ZeroFileType.h"
 #include "deless.h"
+#include <cstring>
 
 IsoHandler::Extractor::Extractor(const char *isoFile, const char *outputFolder)
 {


### PR DESCRIPTION
Removes std from strcmp and adds correct header