### PR TITLE
Adding support to nightly builds

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -67,9 +67,9 @@ jobs:
       if: ${{ matrix.sys.os == 'ubuntu-latest' }}
       working-directory: build
       run: |
-        zip -r Obscura_${{ matrix.sys.name }}_v${{ github.event.inputs.version }}.zip Obscura/*
+        zip -r Obscura_${{ matrix.sys.name }}.zip Obscura/*
 
     - uses: actions/upload-artifact@v4
       with:
-        name: Obscura-nightly-build-${{matrix.sys.os}}
-        path: build/Obscura_${{ matrix.sys.name }}_v${{ github.event.inputs.version }}.zip
+        name: Obscura-nightly-build-${{matrix.sys.name}}
+        path: build/Obscura_${{ matrix.sys.name }}.zip

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -41,5 +41,5 @@ jobs:
 
     - uses: actions/upload-artifact@v4
       with:
-        name: Obscura-nightly-build-${{ matrix.os }}
+        name: Obscura-nightly-build-${{matrix.os}}
         path: ${{runner.workspace}}/build

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -38,3 +38,8 @@ jobs:
     - name: Test
       working-directory: ${{github.workspace}}/build
       run: ctest -C ${{env.BUILD_TYPE}}
+
+    - uses: actions/upload-artifact@v4
+      with:
+        name: Obscura-nightly-build-${{ matrix.os }}
+        path: ${{runner.workspace}}/build

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -8,27 +8,36 @@ on:
 
 env:
   BUILD_TYPE: Release
+  BUILD_STATIC: true
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }} 
+    runs-on: ${{ matrix.sys.os }}
     strategy:
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-latest]
+        sys:
+          - { os: windows-latest, shell: pwsh, name: windows }
+          - { os: ubuntu-latest,  shell: bash, name: linux  }
+          - { os: macos-latest,   shell: bash, name: macos  }
+    defaults:
+      run:
+        shell: ${{ matrix.sys.shell }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
+      with:
+        submodules: 'recursive'
     
     - name: Install Dependencies
-      if: ${{ matrix.os == 'ubuntu-latest' }}
+      if: ${{ matrix.sys.os == 'ubuntu-latest' }}
       run: |
-          sudo apt update
-          sudo apt install libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libgl1-mesa-dev libglu1-mesa-dev
-          sudo apt update
-          sudo apt upgrade
+        sudo apt update
+        sudo apt install zip libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libgl1-mesa-dev libglu1-mesa-dev
+        sudo apt update
+        sudo apt upgrade
 
     - name: Configure CMake
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DBUILD_STATIC=${{env.BUILD_STATIC}}
 
     - name: Build
       run: |
@@ -39,7 +48,28 @@ jobs:
       working-directory: ${{github.workspace}}/build
       run: ctest -C ${{env.BUILD_TYPE}}
 
+    - name: Zip Windows App
+      if: ${{ matrix.sys.os == 'windows-latest' }}
+      working-directory: build/Obscura/Release
+      shell: pwsh
+      run: |
+        Copy-Item "../ZeroFileDictionary.json"
+        Compress-Archive * ../../Obscura_${{ matrix.sys.name }}_v${{ github.event.inputs.version }}.zip
+
+    - name: Zip OSX App
+      if: ${{ matrix.sys.os == 'macos-latest' }}
+      working-directory: build/
+      shell: pwsh
+      run: |
+        Get-ChildItem -Path Obscura/* | Compress-Archive -DestinationPath Obscura_${{ matrix.sys.name }}_v${{ github.event.inputs.version }}.zip
+
+    - name: Zip Ubuntu App
+      if: ${{ matrix.sys.os == 'ubuntu-latest' }}
+      working-directory: build
+      run: |
+        zip -r Obscura_${{ matrix.sys.name }}_v${{ github.event.inputs.version }}.zip Obscura/*
+
     - uses: actions/upload-artifact@v4
       with:
-        name: Obscura-nightly-build-${{matrix.os}}
-        path: ${{runner.workspace}}/build
+        name: Obscura-nightly-build-${{matrix.sys.os}}
+        path: build/Obscura_${{ matrix.sys.name }}_v${{ github.event.inputs.version }}.zip


### PR DESCRIPTION
Adding support to nightly builds, so anyone can test unreleased builds, just in case they can help testing new features

Note: The nightly builds currently have the small issue of being zipped twice, but that's just because I've preserved the compression method from the Release workflow, since I didn't know if those were required for the final builds to work as expected. I can easily fix that by removing the OG zipping, in case that's an issue.